### PR TITLE
Fix failing ansible lint command in CI

### DIFF
--- a/test/lint/.ansible-lint
+++ b/test/lint/.ansible-lint
@@ -1,0 +1,4 @@
+exclude_paths: []
+parseable: true
+use_default_rules: true
+verbosity: true


### PR DESCRIPTION
Missing the ansible lint configuration file which is reference by the ansible lint command. Added the file