### PR TITLE
Remove swagger-ui-enabled from web3signer.yml.j2

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,6 @@ Please refer to the Web3Signer [docs](https://docs.web3signer.consensys.net/en/l
 | web3signer_metrics_categories    | ['HTTP', 'SIGNING', 'JVM', 'PROCESS', 'ETH2_SLASHING_PROTECTION'] | Comma separated list of categories to track metrics for |
 | web3signer_metrics_host_allowlist| ['127.0.0.1']        | Comma separated list of hostnames to allow for metrics access, or * to accept any host |
 | web3signer_idle_connection_timeout_seconds | `30`       | Number of seconds after which an idle connection will be terminated |
-| web3signer_swagger_ui_enabled    | `False`              | Enable swagger UI |
 | web3signer_tls_keystore_file     |                      | Path to a PKCS#12 formatted keystore used to enable TLS on inbound connections |
 | web3signer_tls_keystore_password_file |                 | Path to a file containing the password used to decrypt the keystore |
 | web3signer_tls_allow_any_client  |                      | If defined, any client may connect, regardless of presented certificate. This cannot be set if either a whitelist or CA clients have been enabled |

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -99,4 +99,3 @@ web3signer_metrics_port: 9001
 web3signer_metrics_categories: ['HTTP', 'SIGNING', 'JVM', 'PROCESS', 'ETH2_SLASHING_PROTECTION']
 web3signer_metrics_host_allowlist: ['127.0.0.1']
 web3signer_idle_connection_timeout_seconds: 30
-web3signer_swagger_ui_enabled: False

--- a/templates/web3signer.yml.j2
+++ b/templates/web3signer.yml.j2
@@ -12,7 +12,6 @@ metrics-port: {{ web3signer_metrics_port }}
 metrics-categories: [{{web3signer_metrics_categories|map('to_json')|join(',')}}]
 metrics-host-allowlist: [{{web3signer_metrics_host_allowlist|map('to_json')|join(',')}}]
 idle-connection-timeout-seconds: {{ web3signer_idle_connection_timeout_seconds }}
-swagger-ui-enabled: {{ web3signer_swagger_ui_enabled | to_json }}
 
 {% if web3signer_tls_keystore_file is defined %}
 tls-keystore-file: "{{ web3signer_tls_keystore_file }}"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Removes the swagger UI configuration (`swagger-ui-enabled`/`web3signer_swagger_ui_enabled`) from the template, defaults, and README.
> 
> - **Config/Template**:
>   - Remove `swagger-ui-enabled` from `templates/web3signer.yml.j2`.
>   - Remove `web3signer_swagger_ui_enabled` from `defaults/main.yml`.
> - **Docs**:
>   - Remove `web3signer_swagger_ui_enabled` from `README.md` role variables table.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3197f6f38d714a9c17fd95176054ee876d480029. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->