### PR TITLE
fix: remove collection from role dependencies

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,7 +1,5 @@
 ---
-dependencies:
-  - name: community.general
-    version: 10.1.0
+dependencies: []
 
 galaxy_info:
   author: consensys


### PR DESCRIPTION
## Summary

- Remove `community.general` from `dependencies` in `meta/main.yml`. It is an Ansible **collection**, not a role, so listing it under role `dependencies` causes Ansible to fail with: `the role 'community.general' was not found`.
- The collection is not used by any task in this role, so the entry is simply removed.
- Consumers that need `community.general` should install it via their own `requirements.yml` collections section.

## Context

Introduced in commit ff8d766 ("fix linting"). The `dependencies` field in `meta/main.yml` only supports **role** dependencies, not collection dependencies. When Ansible encounters a collection name there, it tries to resolve it as a role and fails.

## Test plan

- [ ] Run a playbook that includes the `consensys.web3signer` role — it should no longer fail with `the role 'community.general' was not found`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Metadata-only change that removes an unused/invalid dependency reference; low risk aside from consumers that implicitly relied on it being installed.
> 
> **Overview**
> Removes the `community.general` entry from the role’s `meta/main.yml` by setting `dependencies: []`, avoiding Ansible trying (and failing) to resolve a collection as a role dependency.
> 
> No functional task changes are included; this is metadata-only cleanup to prevent role install/run errors tied to dependency resolution.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 190d558f5d97234d022158411dfa5060a09057ed. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->